### PR TITLE
Potential fix for code scanning alert no. 2: HTTP request type unprotected from CSRF

### DIFF
--- a/src/main/java/net/codejava/AppController.java
+++ b/src/main/java/net/codejava/AppController.java
@@ -55,7 +55,7 @@ public class AppController {
 	    return "redirect:/";
 	}
 	
-	@RequestMapping("/delete/{id}")
+	@RequestMapping(value = "/delete/{id}", method = RequestMethod.POST)
 	public String delete(@PathVariable(name = "id") int id) {
 	    dao.delete(id);
 	    return "redirect:/";       

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -29,7 +29,7 @@
                 <td>
                     <a th:href="@{'/edit/' + ${sale.id}}">Edit</a>
                     &nbsp;&nbsp;&nbsp;
-                    <form th:action="@{'/delete/' + ${sale.id}}" method="POST" style="display:inline">
+                    <form th:action="@{'/delete/' + ${sale.id}}" method="post" style="display:inline">
                         <button type="submit" onclick="return confirm('Are you sure?')">Delete</button>
                     </form>
                 </td>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -29,7 +29,9 @@
                 <td>
                     <a th:href="@{'/edit/' + ${sale.id}}">Edit</a>
                     &nbsp;&nbsp;&nbsp;
-                    <a th:href="@{'/delete/' + ${sale.id}}">Delete</a>
+                    <form th:action="@{'/delete/' + ${sale.id}}" method="POST" style="display:inline">
+                        <button type="submit" onclick="return confirm('Are you sure?')">Delete</button>
+                    </form>
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
Potential fix for [https://github.com/liquibase/SalesManager_App/security/code-scanning/2](https://github.com/liquibase/SalesManager_App/security/code-scanning/2)

In general, state‑changing actions (like delete, update, create) must not be exposed via safe HTTP methods such as `GET`. In Spring, you should annotate such handlers with an unsafe HTTP method (`POST`, `PUT`, `PATCH`, `DELETE`), which are covered by Spring Security’s default CSRF protection. For delete operations, it is idiomatic either to use `@PostMapping` or `@DeleteMapping`.

The best minimal fix here is to restrict the `/delete/{id}` handler to an unsafe method while preserving its existing behavior and URL. We will change the annotation from a generic `@RequestMapping("/delete/{id}")` to explicitly specify `method = RequestMethod.POST`. This keeps the same path and return value (`redirect:/`) and only changes the allowed HTTP methods. Any HTML form that triggers this deletion should already be a POST (or can be easily changed in the view), and Spring Security will then apply CSRF protection to this POST request. No changes are needed in `SalesDAO`.

Concretely:
- In `src/main/java/net/codejava/AppController.java`, update the annotation on the `delete` handler (lines 58–61) to:
  ```java
  @RequestMapping(value = "/delete/{id}", method = RequestMethod.POST)
  ```
- Leave `SalesDAO.delete` unchanged; it is the state‑changing sink but does not handle HTTP directly.

No new imports or helper methods are required, since `RequestMethod` is already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
