### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -2,6 +2,8 @@
 # For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-maven
 
 name: Java CI with Maven
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/liquibase/SalesManager_App/security/code-scanning/1](https://github.com/liquibase/SalesManager_App/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block that scopes the `GITHUB_TOKEN` to the least privileges needed. For this Maven CI workflow, the steps only require read access to the repository contents (for `actions/checkout`) and no write operations, so `contents: read` at the workflow or job level is sufficient.

The best fix with minimal functional impact is to add a root-level `permissions` section just under the `name:` field in `.github/workflows/maven.yml`. This will apply to all jobs in the workflow (currently just `build`) and restrict the token to read-only contents, which still allows `actions/checkout@v2` to function correctly. No other scopes (like `pull-requests` or `issues`) are needed, and no other parts of the file need to be changed.

Concretely:
- Edit `.github/workflows/maven.yml`.
- Insert:

  ```yaml
  permissions:
    contents: read
  ```

  between the existing `name: Java CI with Maven` (line 4) and the `on:` section (line 6).  
No imports, methods, or additional definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
