### PR TITLE
Add Spring Security with proper CSRF protection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<dependency>
 				<groupId>org.liquibase</groupId>
 				<artifactId>liquibase-core</artifactId>
 				<version>4.8.0</version>

--- a/src/main/java/net/codejava/AppController.java
+++ b/src/main/java/net/codejava/AppController.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.servlet.ModelAndView;
@@ -55,9 +56,9 @@ public class AppController {
 	    return "redirect:/";
 	}
 	
-	@RequestMapping("/delete/{id}")
+	@PostMapping("/delete/{id}")
 	public String delete(@PathVariable(name = "id") int id) {
 	    dao.delete(id);
-	    return "redirect:/";       
+	    return "redirect:/";
 	}	
 }

--- a/src/main/java/net/codejava/SecurityConfig.java
+++ b/src/main/java/net/codejava/SecurityConfig.java
@@ -1,0 +1,23 @@
+package net.codejava;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth
+                .anyRequest().permitAll()
+            )
+            .csrf(csrf -> csrf.ignoringRequestMatchers("/h2-console/**"))
+            .headers(headers -> headers.frameOptions().sameOrigin());
+        return http.build();
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -29,7 +29,9 @@
                 <td>
                     <a th:href="@{'/edit/' + ${sale.id}}">Edit</a>
                     &nbsp;&nbsp;&nbsp;
-                    <a th:href="@{'/delete/' + ${sale.id}}">Delete</a>
+                    <form th:action="@{'/delete/' + ${sale.id}}" method="POST" style="display:inline">
+                        <button type="submit" onclick="return confirm('Are you sure?')">Delete</button>
+                    </form>
                 </td>
             </tr>
         </tbody>


### PR DESCRIPTION
## Summary

Implements proper CSRF protection using Spring Security.

- Added spring-boot-starter-security dependency
- Created SecurityConfig with CSRF enabled (app remains publicly accessible)
- Updated delete endpoint to use @PostMapping
- Changed delete link to form in index.html

## Why This Approach

The previous fix (PR #7) changed the endpoint to POST but without Spring Security, there's no CSRF token validation. An attacker could still craft a form that auto-submits. This PR adds proper token-based CSRF protection.

Thymeleaf automatically includes CSRF tokens in forms when Spring Security is present, so existing forms in `new_form.html` and `edit_form.html` will also be protected.

## Test Plan

- [ ] Build succeeds: `mvn clean compile`
- [ ] Tests pass: `mvn test`
- [ ] Create/Edit/Delete operations work in browser
- [ ] GET request to /delete/{id} returns 405
- [ ] Forms contain _csrf hidden field

🤖 Generated with [Claude Code](https://claude.com/claude-code)